### PR TITLE
Automatically cleans up STOP file

### DIFF
--- a/brute.lua
+++ b/brute.lua
@@ -164,6 +164,7 @@ function doBruteforce(startString, finalString, startLength, endLength)
 	
 	if fileExists("STOP") == true then
 		print("STOP file detected! Quitting...")
+		os.remove("STOP")
 	else
 		print("Looks like we've hit the bruteforce target. Finished! Quitting...")
 	end


### PR DESCRIPTION
This prevents the user from needing to do a "rm STOP" after doing "touch STOP" to pause/stop the script, as the script will automatically remove the STOP file when finishing up.
